### PR TITLE
fix: enable cors globally

### DIFF
--- a/src/main/java/com/cdt/be/infrastructure/security/CorsConfig.java
+++ b/src/main/java/com/cdt/be/infrastructure/security/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.cdt.be.infrastructure.security;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+  /**
+   * Allow all cross-origin requests.
+   */
+  @Bean
+  public CorsFilter corsFilter() {
+    final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    final CorsConfiguration config = new CorsConfiguration();
+    config.setAllowCredentials(true);
+    config.setAllowedOrigins(Collections.singletonList("*"));
+    config.setAllowedHeaders(List.of("Origin", "Content-Type", "Accept"));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "OPTIONS", "DELETE", "PATCH"));
+    source.registerCorsConfiguration("/**", config);
+    return new CorsFilter(source);
+  }
+}


### PR DESCRIPTION
we need to enable cross-origin request, so we will be able to make request web client.

for now, we can just let all until the domain is decided.