### PR TITLE
feat: deploy docker image to do with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,15 @@ jobs:
               -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
               -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
               -Dbuild.repo=${CIRCLE_PROJECT_REPONAME} \
-              
+      - add_ssh_keys:
+          fingerprints:
+            - "77:9c:f7:e2:0f:12:87:82:63:0f:87:ef:80:cd:93:96"
+      - run:
+          name: Deploy app to DO
+          command: |
+            ssh -o StrictHostKeyChecking=no ${DROPLET_USER}@${DROPLET_IP} "/bin/bash .~/cdt/deploy_app.sh ${IMAGE}"
+
+
 workflows:
   version: 2
   build_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,9 @@ jobs:
           fingerprints:
             - "77:9c:f7:e2:0f:12:87:82:63:0f:87:ef:80:cd:93:96"
       - run:
-          name: Deploy app to DO
+          name: Deploy app to server
           command: |
-            ssh -o StrictHostKeyChecking=no ${DROPLET_USER}@${DROPLET_IP} "/bin/bash .~/cdt/deploy_app.sh ${IMAGE}"
+            ssh -o StrictHostKeyChecking=no ${DEPLOYMENT_USER}@${SERVER} "/bin/bash ./deploy_app.sh ${IMAGE}"
 
 
 workflows:


### PR DESCRIPTION
While adding ssh key to circleci encrypted keys are no longer supported. So in order to resolve this after generating ssh key `openssl rsa -in ~/.ssh/encrpyted_rsa -out ~/.ssh/decryted_rsa` can be used.

resolves #8 