### PR TITLE
chore: generate jacoco report and send to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - *restore_repo
       - *restore_jars
       - run: mvn test
+      - run: "bash <(curl -s https://codecov.io/bash)"
 
   deploy:
     <<: *container_config

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,26 @@
           </container>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <!-- attached to Maven test phase -->
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
"mvn test" generates "target/site/jacoco/index.html" and other reports, codecov bash uploads the related parts to its own service.

closes #11 